### PR TITLE
merging BUSCOs on top of braker.gtf

### DIFF
--- a/bin/best_by_compleasm.py
+++ b/bin/best_by_compleasm.py
@@ -8,11 +8,12 @@ from inspect import currentframe, getframeinfo
 import shutil
 import re
 from datetime import datetime
+from collections import defaultdict
 
 __author__ = "Katharina J. Hoff"
 __copyright__ = "Copyright 2023. All rights reserved."
-__credits__ = ""
-__license__ = "Artistic License 2.0"
+__credits__ = "Huang Neng"
+__license__ = "Artistic License 2.0, in part Apache License (see notes in code about functions copied & modified from compleasm)"
 __version__ = "1.0.0"
 __email__ = "katharina.hoff@uni-greifswald.de"
 __status__ = "development"
@@ -25,7 +26,7 @@ argparser.add_argument('-m', '--tmp_dir', type=str, required = True,
 argparser.add_argument('-c', '--compleasm_bin', type=str, required = False,
                           help = 'Location of compleasm.py on system')
 argparser.add_argument('-d', '--input_dir', type=str, required = True,
-                            help = 'Output directory of BRAKER or GALBA run')
+                            help = 'Output directory of BRAKER')
 argparser.add_argument('-y', '--tsebra', type=str, required = False,
                             help = 'Location of tesbra.py on system')
 argparser.add_argument('-f', '--getanno', type=str, required = False,
@@ -36,8 +37,105 @@ argparser.add_argument('-t', '--threads', type=str, required = False, default = 
                        help = 'Number of threads to use for running compleasm')
 argparser.add_argument('-p', '--busco_db', type=str, required = True,
                             help = 'BUSCO lineage for running compleasm')
+argparser.add_argument('-n', '--missing_busco_threshold', type=int, default = 15,
+                       required = False, help = "Threshold for the percentage of missing BUSCOs that " +
+                       "decides until which point the BUSCOs in augustus and genemark gene sets will " +
+                       "simply be added on top of the braker.gtf gene set, upper boundary.")
 
 args = argparser.parse_args()
+
+# Functions copied from compleasm by Huang Neng under the Apache License 2.0
+# modifications are noted in the comments
+
+def load_score_cutoff(scores_cutoff_file): # changed arguments
+    cutoff_dict = {}
+    try:
+        with open(scores_cutoff_file, "r") as f:
+            for line in f:
+                line = line.strip().split()
+                try:
+                    taxid = line[0]
+                    score = float(line[1])
+                    cutoff_dict[taxid] = score
+                except IndexError:
+                    raise Error("Error parsing the scores_cutoff file.")
+    except IOError:
+        raise Error("Impossible to read the scores in {}".format(scores_cutoff_file))
+    return cutoff_dict
+
+def load_length_cutoff(lengths_cutoff_file): # changed arguments
+    cutoff_dict = {}
+    try:
+        with open(lengths_cutoff_file, "r") as f:
+            for line in f:
+                line = line.strip().split()
+                try:
+                    taxid = line[0]
+                    sigma = float(line[2])
+                    length = float(line[3])
+                    if sigma == 0.0:
+                        sigma = 1
+                    cutoff_dict[taxid] = {}
+                    cutoff_dict[taxid]["sigma"] = sigma
+                    cutoff_dict[taxid]["length"] = length
+                except IndexError:
+                    raise Error("Error parsing the lengths_cutoff file.")
+    except IOError:
+        raise Error("Impossible to read the lengths in {}".format(lengths_cutoff_file))
+    return cutoff_dict
+
+def parse_hmmsearch_output(hmm_out_dir, score_cutoff_dict, length_cutoff_dict): # turned this into a function
+    busco_tx = {}
+    for hmmsearch_output in os.listdir(hmm_out_dir):
+        outfile = os.path.join(hmm_out_dir, hmmsearch_output)
+        try:
+            if outfile.endswith(".out"): # changed that summary.txt is ignored
+                with open(outfile, 'r') as fin:
+                    coords_dict = defaultdict(list)
+                    for line in fin:
+                        if line.startswith('#'):
+                            continue
+                        line = line.strip().split()
+                        target_name = line[0]
+                        query_name = line[3]
+                        hmm_score = float(line[7])
+                        hmm_from = int(line[15])
+                        hmm_to = int(line[16])
+                        assert hmm_to >= hmm_from
+                        if hmm_score < score_cutoff_dict[query_name]:
+                            # failed to pass the score cutoff
+                            continue
+                        coords_dict[target_name].append((hmm_from, hmm_to))
+                    for tname in coords_dict.keys():
+                        coords = coords_dict[tname]
+                        interval = []
+                        coords = sorted(coords, key=lambda x: x[0])
+                        for i in range(len(coords)):
+                            hmm_from, hmm_to = coords[i]
+                            if i == 0:
+                                interval.extend([hmm_from, hmm_to, hmm_to - hmm_from])
+                            else:
+                                try:
+                                    assert hmm_from >= interval[0]
+                                except:
+                                    raise Error("Error parsing the hmmsearch output file {}.".format(outfile))
+                                if hmm_from >= interval[1]:
+                                    interval[1] = hmm_to
+                                    interval[2] += hmm_to - hmm_from
+                                elif hmm_from < interval[1] <= hmm_to:
+                                    interval[2] += hmm_to - interval[1]
+                                    interval[1] = hmm_to
+                                elif hmm_to < interval[1]:
+                                    continue
+                                else:
+                                    raise Error("Error parsing the hmmsearch output file {}.".format(outfile))
+                        busco_tx[tname] = 0 # change that targets to with BUSCO hits are stored
+        except IOError:
+            print("Error opening file {}".format(outfile))
+            sys.exit(1)
+    return busco_tx
+
+# end of functions under Apache License 2.0
 
 def parse_compleasm(file):
     """
@@ -79,18 +177,15 @@ def find_input_files(args):
     """
     file_paths = {}
     file_paths["braker_aa"] = check_file(os.path.join(args.input_dir, "braker.aa"))
-    file_paths["galba_aa"] = check_file(os.path.join(args.input_dir, "galba.aa"))
     file_paths["augustus_aa"] = check_file(os.path.join(args.input_dir, "Augustus", "augustus.hints.aa"))
     if not file_paths["augustus_aa"]:
         file_paths["augustus_aa"] = check_file(os.path.join(args.input_dir, "augustus.hints.aa"))
     file_paths["genome"] = check_file(args.genome)  # required to generate genemark protein file
     file_paths["hints"] = check_file(os.path.join(args.input_dir, "hintsfile.gff"))  # required to possibly run TSEBRA
     file_paths["braker_gtf"] = check_file(os.path.join(args.input_dir, "braker.gtf"))
-    file_paths["galba_gtf"] = check_file(os.path.join(args.input_dir, "galba.gtf"))
     file_paths["augustus_gtf"] = check_file(os.path.join(args.input_dir, "Augustus", "augustus.hints.gtf"))
     if not file_paths["augustus_gtf"]:
         file_paths["augustus_gtf"] = check_file(os.path.join(args.input_dir, "augustus.hints.gtf")) 
-    file_paths["miniprot_trainingGenes.gtf"] = check_file(os.path.join(args.input_dir, "miniprot_trainingGenes.gtf"))
     return file_paths
 
 def find_genemark_gtf(input_dir):
@@ -136,15 +231,25 @@ def run_compleasm(protein_files, threads, busco_db, tmp_dir):
 
     """
     # download the BUSCO database if not present
-    if not os.path.exists("mb_downloads/" + args.busco_db):
-        # cut off the _odb10 suffix from args.busco_db
+    if not os.path.exists("mb_downloads/" + busco_db):
+        # cut off the _odb10 suffix from busco_db
         # if it exists
-        if args.busco_db.endswith("_odb10"):
-            busco_db = args.busco_db[:-6]
-        else:
-            busco_db = args.busco_db
+        if busco_db.endswith("_odb10"):
+            busco_db = busco_db[:-6]
         compleasm_cmd = [args.compleasm_bin, "download", busco_db]
         run_simple_process(compleasm_cmd)
+    
+    # read key data of BUSCO lineage
+    # changed arguments in the following 2 calls
+    # use args.busco_db and not busco_db because the suffix needs to remain here
+    score_cutoff_dict = load_score_cutoff(os.path.join("mb_downloads/" + args.busco_db, "scores_cutoff"))
+    length_cutoff_dict = load_length_cutoff(os.path.join("mb_downloads/" + args.busco_db, "lengths_cutoff"))
+
+    protein_hmmsearch_output_dict = {}  ## key: hmm protein name, value: list of aligned hmm and complete or fragment
+    for profile in os.listdir(os.path.join("mb_downloads/" + args.busco_db, "hmms")):
+        outfile = profile.replace(".hmm", ".out")
+        target_specie = profile.replace(".hmm", "")
+        protein_hmmsearch_output_dict[target_specie] = []
 
     # run compleasm on the protein files
     for protein_file in protein_files:
@@ -161,7 +266,7 @@ def run_compleasm(protein_files, threads, busco_db, tmp_dir):
         tool = re.search(r'^([^.]+)\.', os.path.basename(protein_file)).group(1)
         result_dict[tool] = check_file(tmp_dir + "/" + tool + "/summary.txt")
 
-    return result_dict
+    return result_dict, score_cutoff_dict, length_cutoff_dict, protein_hmmsearch_output_dict
 
 def run_getanno(annobin, genome_file, gtf, output_dir):
     """
@@ -268,13 +373,13 @@ def check_file(file):
 
 def determine_mode(path_dir):
     """
-    Determine whether BRAKER or GALBA was run, and whether the files are complete.
+    Determine whether BRAKER run, and whether the files are complete.
 
     Args:
         path_dir (dict): Dictionary containing the file paths.
 
     Returns:
-        str: Mode of the run (BRAKER or GALBA).
+        str: Mode of the run (BRAKER).
 
     Raises:
         SystemExit: If the files are not complete for either of the runs
@@ -282,14 +387,11 @@ def determine_mode(path_dir):
     """
     if path_dir["braker_aa"] and path_dir["braker_gtf"] and path_dir["hints"] and path_dir["genome"] and path_dir["augustus_aa"] and path_dir["augustus_gtf"] and path_dir["genemark_gtf"] and path_dir["hints"]:
         return "BRAKER"
-    elif path_dir["galba_aa"] and path_dir["galba_gtf"] and path_dir["miniprot_trainingGenes.gtf"] and path_dir["genome"] and path_dir["hints"]:
-        return "GALBA"
     else:
         print("ERROR: The specified directory does not contain all required files.")
         print("These are the files that were found:")
         print(path_dir)
         print("We require the following key files for a BRAKER run: braker.aa, braker.gtf, hintsfile.gff, genome.fa, augustus.hints.aa, augustus.hints.gtf, genemark.gtf, hintsfile.gff")
-        print("We require the following key files for a GALBA run: galba.aa, galba.gtf, miniprot_trainingGenes.gtf, genome.fa, hintsfile.gff")
         sys.exit(1)
 
 
@@ -310,6 +412,44 @@ def check_dir(dir):
         print("ERROR: Directory not found: " + dir)
         sys.exit(1)
 
+def write_busco_keep_gtf(tx_dict, in_file, out_file):
+    """
+    Filters and writes GTF lines based on transcript IDs.
+
+    This function reads a GTF file specified by 'in_file', filters its contents
+    based on the presence of transcript IDs in 'tx_dict', and writes the 
+    filtered content to 'out_file'. It retains lines starting with '#' 
+    (comments) and writes only the lines where the transcript ID is found in
+      'tx_dict'.
+
+    Args:
+        tx_dict (dict): A dictionary where keys are transcript IDs to be kept.
+        in_file (str): Path to the input GTF file to be read.
+        out_file (str): Path to the output file where filtered lines are 
+                        written.
+
+    Raises:
+        IOError: If there is an error opening 'in_file' or 'out_file'.
+
+    Notes:
+        The function exits the script with a status of 1 if an IOError is 
+        encountered.
+        It assumes that each line in the GTF file has a 'transcript_id' 
+        attribute.
+    """
+    try:
+        with open(in_file, 'r') as fin, open(out_file, 'w') as fout:
+            for line in fin:
+                if line.startswith('#'):
+                    continue
+                if re.search(r'transcript_id \"([^"]+)\"', line):
+                    tx_id = re.search(r'transcript_id \"([^"]+)\"', line).group(1)
+                    if tx_id in tx_dict:
+                        fout.write(line)
+    except IOError:
+        print("Error opening file " + in_file + " or " + out_file)
+        sys.exit(1)
+
 def main():
     """
     Execute workflow
@@ -321,7 +461,7 @@ def main():
     # Step 2: find out which GeneMark was used: ETP or EP or ET or ES or none
     file_paths["genemark_gtf"], file_paths["training_gtf"] = find_genemark_gtf(args.input_dir)
 
-    # Step 3: determine whether BRAKER was run or GALBA, and whether files are complete
+    # Step 3: determine whether BRAKER was run and whether files are complete
     w_mode = determine_mode(file_paths)
 
     # Step 4: Check if all dependencies are available
@@ -341,26 +481,18 @@ def main():
     if w_mode == "BRAKER":
         # Step 6: Create protein sequene file for GeneMark gtf file
         file_paths["genemark_aa"] = run_getanno(args.getanno, args.genome, file_paths["genemark_gtf"], args.tmp_dir)
-    elif w_mode == "GALBA":
-        file_paths["miniprot_trainingGenes_aa"] = run_getanno(args.getanno, args.genome, file_paths["miniprot_trainingGenes.gtf"], args.tmp_dir)
 
     # Step 7: run compleasm
     if w_mode == "BRAKER":
         protein_file_list = [file_paths["genemark_aa"], file_paths["braker_aa"], file_paths["augustus_aa"]]
-    elif w_mode == "GALBA":
-        protein_file_list = [file_paths["miniprot_trainingGenes_aa"], file_paths["galba_aa"]]
 
-    compleasm_out_dict = run_compleasm(protein_file_list, args.threads, args.busco_db, args.tmp_dir)
+    compleasm_out_dict, score_dict, length_dict, protein_hmmsearch_dict = run_compleasm(protein_file_list, args.threads, args.busco_db, args.tmp_dir)
 
     # Step 8: parse and compare the number of missing BUSCOs
-
     if w_mode == "BRAKER":
         genemark_missing = parse_compleasm(compleasm_out_dict["genemark"])
         augustus_missing = parse_compleasm(compleasm_out_dict["augustus"])
         braker_missing = parse_compleasm(compleasm_out_dict["braker"])
-    elif w_mode == "GALBA":
-        galba_missing = parse_compleasm(compleasm_out_dict["galba"])
-        miniprot_trainingGenes_missing = parse_compleasm(compleasm_out_dict["miniprot_trainingGenes"])
 
     
     # Step 9: Decide whether the provided final gene set is good enough
@@ -368,48 +500,76 @@ def main():
         print("BRAKER is missing " + str(braker_missing) + " BUSCOs.")
         print("GeneMark is missing " + str(genemark_missing) + " BUSCOs.")
         print("Augustus is missing " + str(augustus_missing) + " BUSCOs.")
-        if braker_missing <= 5 and braker_missing <= augustus_missing and braker_missing <= genemark_missing:
+        if braker_missing <= augustus_missing and braker_missing <= genemark_missing:
             print("The BRAKER gene set " + file_paths["braker_gtf"] + " is the best one. It lacks " + str(braker_missing) + "% BUSCOs.")
             sys.exit(0)
-        elif augustus_missing >= genemark_missing:
-            tsebra_force = file_paths["genemark_gtf"]
-            not_tsebra_force = file_paths["augustus_gtf"]
-        else:
+        elif braker_missing <= args.missing_busco_threshold and (augustus_missing < braker_missing or genemark_missing < braker_missing):
+            print("All BUSCOs present in augustus.hints.gtf and genemark.gtf will be added to the braker.gtf gene set.")
+            # in this case we want to find the BUSCOs in all gene sets and merge them on top of the braker gene set
+            tsebra_force = file_paths["braker_gtf"]
+        elif augustus_missing < braker_missing:
             tsebra_force = file_paths["augustus_gtf"]
             not_tsebra_force = file_paths["genemark_gtf"]
-    elif w_mode == "GALBA":
-        print("GALBA is missing " + str(galba_missing) + " BUSCOs.")
-        print("miniprot_trainingGenes is missing " + str(miniprot_trainingGenes_missing) + " BUSCOs.")
+            print("Will enforce augustus.hints.gtf and the BUSCOs from augustus and genemark gene set.")
+        elif genemark_missing < braker_missing:
+            print("Will enforce genemark.gtf and the BUSCOs from augustus and genemark gene set.")
+            tsebra_force = file_paths["genemark_gtf"]
+            not_tsebra_force = file_paths["augustus_gtf"]
+        # used to have a case for GALBA but that was removed because we implemented DIAMOND filter for GALBA, instead
 
-        if galba_missing <= miniprot_trainingGenes_missing:
-            print("The GALBA gene set " + file_paths["galba_gtf"] + " is the best one. It lacks " + str(galba_missing) + "% BUSCOs.")
-            sys.exit(0)
-        else:
-            tsebra_force = file_paths["miniprot_trainingGenes_gtf"]
-            not_tsebra_force = file_paths["galba_gtf"]
+    # Step 10: find the BUSCOs in augustus and genemark gene sets
+    keep_aug_dict = parse_hmmsearch_output(os.path.join(args.tmp_dir, "augustus"), score_dict, length_dict)
+    write_busco_keep_gtf(keep_aug_dict, file_paths["augustus_gtf"], args.tmp_dir + "/augustus_keep.gtf")
+    # find the BUSCOs in genemark.gtf
+    keep_gm_dict = parse_hmmsearch_output(os.path.join(args.tmp_dir, "genemark"), score_dict, length_dict)
+    write_busco_keep_gtf(keep_gm_dict, file_paths["genemark_gtf"], args.tmp_dir + "/genemark_keep.gtf")
+    # concatenate the two keep gtf files
+    try:
+        with open(args.tmp_dir + "/augustus_keep.gtf", 'r') as fin, open(args.tmp_dir + "/genemark_keep.gtf", 'r') as fin2, open(args.tmp_dir + "/augustus_genemark_keep.gtf", 'w') as fout:
+            for line in fin:
+                fout.write(line)
+            for line in fin2:
+                fout.write(line)
+    except IOError:
+        print("Error opening file " + args.tmp_dir + "/augustus_keep.gtf" + " or " + args.tmp_dir + "/genemark_keep.gtf")
+        sys.exit(1)
 
-    # Step 10: Run TSEBRA and enforce the best gene set
+    # Step 11: Run TSEBRA and enforce the best gene set
     if w_mode == "BRAKER":
-        if file_paths['training_gtf']:
-            tsebra_cmd = [args.tsebra, "-k", file_paths["training_gtf"] + "," + tsebra_force,
-                      "-g", not_tsebra_force, "-e", file_paths["hints"], "-o", args.tmp_dir + "/better.gtf"]
+        if tsebra_force == file_paths["braker_gtf"]:
+            # if augustus_genemark_keep.gtf is not empty
+            if os.stat(args.tmp_dir + "/augustus_genemark_keep.gtf").st_size > 0:
+                tsebra_cmd = [args.tsebra, "-k", tsebra_force + "," + args.tmp_dir + "/augustus_genemark_keep.gtf",
+                         "-o", args.tmp_dir + "/better.gtf", "-q"]
+            else:
+                print("Attempted to merge additional BUSCOs onto braker.gtf but there are no BUSCOs to be added.")
+                print("The BRAKER gene set " + file_paths["braker_gtf"] + " is the best one. It lacks " + str(braker_missing) + "% BUSCOs.")
+                sys.exit(0)
+        elif file_paths['training_gtf']:
+            tsebra_cmd = [args.tsebra, "-k", file_paths["training_gtf"] + "," + tsebra_force # enforcing training.gtf may seem redundant if genemark is enforced but it causes no harm, and it must be enforced if augustus is enforced
+                          + "," + args.tmp_dir + "/augustus_genemark_keep.gtf",
+                          "-g", not_tsebra_force, "-e", file_paths["hints"], "-o", args.tmp_dir + "/better.gtf", "-q"]
         else:
             print("Warning: No training.gtf file found. TSEBRA will be run without it, you may be using an older version of BRAKER.")
-            tsebra_cmd = [args.tsebra, "-k", tsebra_force,
-                      "-g", not_tsebra_force, "-e", file_paths["hints"], "-o", args.tmp_dir + "/better.gtf"]
-    elif w_mode == "GALBA":
-        tsebra_cmd = [args.tsebra, "-k", tsebra_force,
-                      "-g", not_tsebra_force, "-e", file_paths["hints"], "-o", args.tmp_dir + "/better.gtf"]
+            tsebra_cmd = [args.tsebra, "-k", tsebra_force + "," + args.tmp_dir + "/augustus_genemark_keep.gtf",
+                      "-g", not_tsebra_force, "-e", file_paths["hints"], "-o", args.tmp_dir + "/better.gtf", "-q"]
     run_simple_process(tsebra_cmd)
+    # name genes/transcripts consistently
+    shutil.move(args.tmp_dir + "/better.gtf", args.tmp_dir + "/better_tmp.gtf")
+    # replace tsebra.py by gtf_rename.py in args.tsebra
+    rename_gtf = args.tsebra.replace("tsebra.py", "rename_gtf.py")
+    gtf_rename_cmd = [rename_gtf, "--gtf", args.tmp_dir + "/better_tmp.gtf", "--out", args.tmp_dir + "/better.gtf"]
+    run_simple_process(gtf_rename_cmd)
+    os.remove(args.tmp_dir + "/better_tmp.gtf")
 
-    # Step 11: generate protein sequence file for the new BRAKER gene set
+    # Step 12: generate protein sequence file for the new BRAKER gene set
     better_gtf = check_file(args.tmp_dir + "/better.gtf")
     bb_aa = run_getanno(args.getanno, args.genome, better_gtf, args.tmp_dir)
 
-    # Step 12: Run compleasm on the new gene set
-    secondary_compleasm_out = run_compleasm([bb_aa], args.threads, args.busco_db, args.tmp_dir)
+    # Step 13: Run compleasm on the new gene set
+    secondary_compleasm_out, score_dict, length_dict, protein_hmmsearch_dict = run_compleasm([bb_aa], args.threads, args.busco_db, args.tmp_dir)
 
-    # Step 13: parse compleasm output and report numbers
+    # Step 14: parse compleasm output and report numbers
     better_missing = parse_compleasm(list(secondary_compleasm_out.values())[0])
     if w_mode == "BRAKER":
         if better_missing < braker_missing:
@@ -427,40 +587,22 @@ def main():
                 file_paths["genemark_gtf"]: genemark_missing,
                 file_paths["augustus_gtf"]: augustus_missing
             }
+
             # Find the minimum value among the three
             min_value = min(gene_set_values.values())
-            # Find the gene set name associated with the minimum value
-            min_gene_set = None
-            for gene_set, value in gene_set_values.items():
-                if value == min_value:
-                    min_gene_set = gene_set
-                    break
+
+            # Check if braker.gtf has the smallest number of missing BUSCOs or is tied for the smallest number
+            if gene_set_values[file_paths["braker_gtf"]] == min_value:
+                min_gene_set = file_paths["braker_gtf"]
+            else:
+                # Find the gene set name associated with the minimum value (excluding braker.gtf)
+                for gene_set, value in gene_set_values.items():
+                    if gene_set != file_paths["braker_gtf"] and value == min_value:
+                        min_gene_set = gene_set
+                        break
             # Print the name of the gene set with the lowest number of missing BUSCOs
             print(min_gene_set)
-    elif w_mode == "GALBA":
-        if better_missing < galba_missing:
-            print("The new best GALBA gene set is " + better_gtf + ".")
-        else:
-            # if the new gene set is not superior, produce an output that tells the user what
-            # of the previously existing gene sets had the lowest percentage of missing BUSCOs
-            print("WARNING: The new GALBA gene set is not better than the original one :-(")
-            print("The best gene set produced by the original GALBA run is:")
-            gene_sets = [file_paths["galba_gtf"], file_paths["miniprot_trainingGenes_gtf"]]
-            # Create a dictionary to map gene set names to their respective missing values
-            gene_set_values = {
-                file_paths["galba_gtf"]: galba_missing,
-                file_paths["miniprot_trainingGenes_gtf"]: miniprot_trainingGenes_missing
-            }
-            # Find the minimum value among the three
-            min_value = min(gene_set_values.values())
-            # Find the gene set name associated with the minimum value
-            min_gene_set = None
-            for gene_set, value in gene_set_values.items():
-                if value == min_value:
-                    min_gene_set = gene_set
-                    break
-            # Print the name of the gene set with the lowest number of missing BUSCOs
-            print(min_gene_set) 
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
changing the strategy in best_by_compleasm: now, missing BUSCOs are detected in genemark and augustus gene set, and if missing score is below a certain threshold (by default 15%), only the missing BUSCOs are added on top of the braker gene set. Otherwise, they are also enforced in the tsebra reruns.

GALBA support was removed because that problem is now solved with DIAMOND filter.